### PR TITLE
fix: fetch release manifest as release asset

### DIFF
--- a/scripts/check-release-meta.js
+++ b/scripts/check-release-meta.js
@@ -36,7 +36,7 @@ async function fetchLatestReleaseVersion() {
 async function fetchLatestManifestVersion() {
   const response = await fetch(MANIFEST_URL, {
     headers: {
-      Accept: 'application/json',
+      Accept: 'application/octet-stream',
       'User-Agent': 'botassist-site-release-check'
     },
     redirect: 'follow'

--- a/src/lib/appRelease.js
+++ b/src/lib/appRelease.js
@@ -161,10 +161,10 @@ function normalizeReleaseMeta(base, releaseInfo = {}) {
   }
 }
 
-async function fetchJson(url, userAgent) {
+async function fetchJson(url, userAgent, accept = 'application/vnd.github+json, application/json') {
   const response = await fetch(url, {
     headers: {
-      Accept: 'application/vnd.github+json, application/json',
+      Accept: accept,
       'User-Agent': userAgent,
     },
     redirect: 'follow',
@@ -185,7 +185,8 @@ async function fetchJson(url, userAgent) {
 async function fetchLatestManifest() {
   return fetchJson(
     `${RELEASE_PAGE_URL}/download/${RELEASE_MANIFEST_FILE}`,
-    'botassist-site-release-manifest'
+    'botassist-site-release-manifest',
+    'application/octet-stream'
   )
 }
 


### PR DESCRIPTION
## Summary
- request release-manifest.json with octet-stream semantics so Node fetch resolves the public asset correctly
- align the release drift check with the same asset-fetch behavior
- keep the fallback path unchanged when the manifest is unavailable