### PR TITLE
site: align landing with app release v4.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ O site consulta os manifests publicados pelo `electron-builder` no repositório 
 
 Quando existe asset direto para a plataforma, o botão aponta para ele. Quando não existe, o fallback é a página de releases do BotAssist.
 
-Hoje a landing está alinhada com a linha estável `v4.2.5` do app desktop (release de segurança).
+Hoje a landing deve acompanhar a linha estável `v4.2.6` do app desktop.
 
 ## Stack
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,20 @@
 
 Registro editorial das novidades destacadas no site do BotAssist.
 
+## 4.2.6 - 2026-04-22
+
+### Resumo curto
+Release estável focada em consolidar o patch de segurança na linha publicada, alinhar versão, CI e comunicação pública sem reescrever a prerelease `v4.2.5`.
+
+### Destaques para comunicacao
+- A linha estável publicada passa a ser `v4.2.6`.
+- O CI do app volta a falhar para vulnerabilidades críticas novas, mantendo exceção explícita apenas para a cadeia transitiva já documentada.
+- Notas públicas, advisory e artefatos publicados passam a refletir o estado real da release.
+- Site ajustado para apontar a release estável correta e reduzir drift entre landing e GitHub Releases.
+
+### Mensagem pronta (versao curta)
+BotAssist 4.2.6 está no ar: patch estável de alinhamento pós-segurança, com release correta, CI mais rastreável e downloads consistentes para Windows, macOS e Linux.
+
 ## 4.2.3 - 2026-03-22
 
 ### Resumo curto

--- a/docs/case.md
+++ b/docs/case.md
@@ -1,7 +1,7 @@
 # Case - BotAssist Site
 
 ## Propósito
-Este repositório hospeda o site oficial do BotAssist. A landing deve comunicar o aplicativo gratuito, registrar o estado da release estável (hoje `v4.2.4`) e encaminhar tráfego direto para os assets reais dos lançamentos.
+Este repositório hospeda o site oficial do BotAssist. A landing deve comunicar o aplicativo gratuito, registrar o estado da release estável (hoje `v4.2.6`) e encaminhar tráfego direto para os assets reais dos lançamentos.
 
 ## Responsabilidades principais
 - apresentar o BotAssist como produto desktop gratuito, open-source e distribuído por canais reais (`stable`, `beta`, `rc`)

--- a/src/lib/releaseMeta.js
+++ b/src/lib/releaseMeta.js
@@ -1,32 +1,32 @@
 export const releaseMeta = {
-  version: '4.2.5',
+  version: '4.2.6',
   date: '2026-04-22',
-  badge: 'Release de segurança com correções críticas de vulnerabilidades',
-  title: 'Atualização de segurança: correções de vulnerabilidades críticas',
+  badge: 'Release estável com alinhamento operacional pós-segurança',
+  title: 'Alinhamento operacional da release de segurança',
   summary:
-    'Release de segurança crítica focada em corrigir vulnerabilidades em dependências. Atualizações de segurança para @xmldom/xmldom, lodash e nodemailer. Todas as correções testadas e validadas sem breaking changes.',
+    'Patch estável focado em promover a correção de segurança para a linha publicada com versão coerente, gate de audit rastreável no CI e documentação alinhada ao estado real da release.',
   cards: [
     {
-      title: 'Segurança reforçada',
+      title: 'Gate rastreável de audit',
       description:
-        'Correção de 4 vulnerabilidades críticas em dependências: @xmldom/xmldom (CVE-2026-34601), lodash (2 vulnerabilidades) e nodemailer.'
+        'O CI deixa de ignorar vulnerabilidades críticas novas e passa a aceitar apenas a cadeia transitiva documentada do baileys/libsignal/protobufjs.'
     },
     {
-      title: 'Testes completos',
+      title: 'Versão publicada coerente',
       description:
-        'Todas as 60+ testes unitários passando, linting e formatação OK, builds funcionais em todas as plataformas.'
+        'A linha estável sobe para 4.2.6 sem reescrever a prerelease v4.2.5, mantendo comunicação, tag e artefatos alinhados.'
     },
     {
-      title: 'Documentação transparente',
+      title: 'Documentação corrigida',
       description:
-        'Vulnerabilidades documentadas em SECURITY_ADVISORY_2026-04-22.md. Processo de segurança estabelecido para monitoramento contínuo.'
+        'Notas públicas e advisory passam a refletir o estado real da release e da validação executada.'
     }
   ],
   highlights: [
-    '@xmldom/xmldom atualizado para 0.8.13 corrigindo injeção XML (CVE-2026-34601).',
-    'lodash atualizado para 4.18.1 corrigindo 2 vulnerabilidades (injeção de código e poluição de protótipo).',
-    'nodemailer atualizado via mailparser corrigindo injeção SMTP.',
-    'Todas as correções testadas sem breaking changes para usuários existentes.'
+    'CI volta a falhar para vulnerabilidades críticas novas e aceita apenas a cadeia transitiva já documentada.',
+    'Versão do app, lockfile e changelog estruturado sobem juntos para 4.2.6.',
+    'Documentação de segurança e release deixa de sobredeclarar o estado de validação.',
+    'Patch revalidado com testes automatizados e gate dedicado de security audit.'
   ],
   requirements: {
     windows: 'Windows 10/11 64-bit',


### PR DESCRIPTION
## Resumo
- alinhar o fallback editorial do site com a release estavel v4.2.6 do app
- corrigir README, docs/case e release notes do site para reduzir drift de comunicacao
- disparar um deploy novo para substituir a versao desatualizada em producao

## Validacao
- npm run check:release-meta
- npm run lint
- npm run build
- npm run smoke
- validacao manual local da home e de /api/latest-download com 4.2.6